### PR TITLE
Fixed 1 issue of type: PYTHON_E251 throughout 1 file in repo.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
             ["driver_wrap.pyx"],
 
             # include paths
-            include_dirs = ['spdk/include'],
+            include_dirs=['spdk/include'],
             
             # dpdk prebuilt static libraries
             libraries=['uuid', 'numa', 'pthread'],


### PR DESCRIPTION
PYTHON_E251: 'unexpected spaces around keyword / parameter equals'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.