### PR TITLE
To start execution commands after shutdown operation, a Controller Re…

### DIFF
--- a/driver_test.py
+++ b/driver_test.py
@@ -692,9 +692,11 @@ def test_subsystem_shutdown_notify(nvme0, subsystem, repeat):
     logging.info("power cycles: %d" % powercycle)
 
     subsystem.shutdown_notify()
+    nvme0.reset()
     assert powercycle == get_power_cycles(nvme0)
 
     subsystem.shutdown_notify(True)
+    nvme0.reset()
     assert powercycle == get_power_cycles(nvme0)
 
 


### PR DESCRIPTION
…set is requited.

To start executing commands on the controller after a shutdown operation (CSTS.SHST set to 10b), a Controller Reset (CC.EN cleared to ‘0’) is required